### PR TITLE
feat: add option to change base url of github

### DIFF
--- a/__tests__/getToken.spec.ts
+++ b/__tests__/getToken.spec.ts
@@ -181,4 +181,19 @@ describe('getToken', () => {
       '"Input is not valid, either privateKey or privateKeyLocation should be provided"'
     );
   });
+
+  it('Uses other baseUrl if provided', async () => {
+    const other_url = 'https://test.de';
+    const github = nock(other_url).post(getAccessTokensURL(123456)).reply(201, response);
+
+    const { token } = await getToken({
+      appId: APP_ID,
+      installationId: 123456,
+      privateKey: PRIVATE_KEY,
+      baseUrl: other_url,
+    });
+
+    expect(token).toMatchInlineSnapshot('"secret-installation-token-1234"');
+    expect(github.isDone()).toBe(true);
+  });
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -21,6 +21,10 @@ program
     'path to the key location, for more information https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#generating-a-private-key '
   )
   .option('--rawResponse', 'It will return the full response in stringified json format (not just the token)')
+  .option(
+    '--baseUrl <baseUrl>',
+    'Change the base url for github request. For example if used on a Github Enterprise Server instance.'
+  )
 
   .action(getTokenCommand);
 

--- a/src/commands/getToken.ts
+++ b/src/commands/getToken.ts
@@ -20,6 +20,7 @@ interface GetTokenInput {
   appId: number;
   installationId: number;
   privateKey: string;
+  baseUrl?: string;
 }
 type RequestOptions = RequestRequestOptions & Required<{ rawResponse: true }>;
 type PlainRequest = RequestRequestOptions & { rawResponse?: false };
@@ -33,7 +34,7 @@ export async function getToken(
   requestOptions?: PlainRequest
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'>>;
 export async function getToken(
-  { appId, installationId, privateKey }: GetTokenInput,
+  { appId, installationId, privateKey, baseUrl }: GetTokenInput,
   requestOptions?: PlainRequest | RequestOptions
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'> | AppsCreateInstallationAccessTokenResponse> {
   const key = new NodeRSA(privateKey);
@@ -54,6 +55,7 @@ export async function getToken(
       id: appId,
       privateKey: key.exportKey('pkcs8-private-pem'),
     },
+    baseUrl,
     request,
   });
 


### PR DESCRIPTION
Added new parameter for specifying a different URL for github.
This is useful if a github enterprise instance is hosted and you want to use the code there.

No breaking change.