### PR TITLE
reusable workflow for get node version

### DIFF
--- a/.github/workflows/node_version.yml
+++ b/.github/workflows/node_version.yml
@@ -1,0 +1,27 @@
+name: Get node version
+
+on:
+  workflow_call:
+    inputs:
+      nvmrc_location:
+        description: "nvmrc location, by default located at the repository's root"
+        type: string
+        required: false
+        default: '.nvmrc'
+    outputs:
+      node_version:
+        description: 'node version obtained'
+        value: ${{ jobs.setNodeVersion.outputs.NODE_VERSION }}
+
+jobs:
+  setNodeVersion:
+    runs-on: ubuntu-latest
+    outputs:
+      NODE_VERSION: ${{ steps.getVersion.outputs.NODE_VERSION }}
+    steps:
+      - uses: actions/checkout@main
+      - name: Reading ${{ inputs.nvmrc_location }}
+        id: getVersion
+        run: echo "##[set-output name=NODE_VERSION;]$(cat ${{ inputs.nvmrc_location }})"
+      - name: version found ${{ steps.getVersion.outputs.NODE_VERSION }}
+        run: echo ${{ steps.getVersion.outputs.NODE_VERSION }}


### PR DESCRIPTION
I want to make sure I'm using the correct node version when setting up a workflow. So I wrote this tiny workflow that will be able to be reusable across all the other workflows in this repo. 

I'm landing the workflow first so the others can reference it `@main`. 

a common use of this workflow, say for lining will look like [this](https://github.com/gagoar/github-app-installation-token/pull/126/files#diff-717013d02a8afac81852f25ba8ecd3cc0ca53a7f1fe25bedebfd66d6f518d21c)