### PR TITLE
Add `repo` option to narrow down token scope

### DIFF
--- a/__tests__/getToken.spec.ts
+++ b/__tests__/getToken.spec.ts
@@ -196,4 +196,19 @@ describe('getToken', () => {
     expect(token).toMatchInlineSnapshot('"secret-installation-token-1234"');
     expect(github.isDone()).toBe(true);
   });
+
+  it('Takes a list of repository names', async () => {
+    const repos = ['repo1', 'repo2'];
+    const github = nock(GITHUB_URL).post(getAccessTokensURL(123456)).reply(201, response);
+
+    const { token } = await getToken({
+      appId: APP_ID,
+      installationId: 123456,
+      privateKey: PRIVATE_KEY,
+      repositoryNames: repos,
+    });
+
+    expect(token).toMatchInlineSnapshot('"secret-installation-token-1234"');
+    expect(github.isDone()).toBe(true);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@types/debug": "4.1.7",
         "@types/jest": "26.0.24",
-        "@types/node": "16.11.43",
+        "@types/node": "^16.11.43",
         "@types/node-rsa": "1.1.1",
         "@typescript-eslint/eslint-plugin": "5.27.0",
         "@typescript-eslint/parser": "5.27.0",
@@ -544,12 +544,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -557,18 +551,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
@@ -617,6 +599,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
@@ -2184,13 +2188,10 @@
       "dev": true
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/arr-diff": {
       "version": "4.0.0",
@@ -4153,12 +4154,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4313,18 +4308,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/eslint/node_modules/strip-json-comments": {
@@ -8007,13 +7990,12 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -10524,6 +10506,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/prettier-eslint-cli/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/prettier-eslint-cli/node_modules/cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -10692,6 +10683,19 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier-eslint-cli/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/prettier-eslint-cli/node_modules/levn": {
@@ -11259,6 +11263,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/prettier-eslint/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/prettier-eslint/node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -11456,6 +11469,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/prettier-eslint/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/prettier-eslint/node_modules/json-schema-traverse": {
@@ -12910,7 +12936,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/sshpk": {
@@ -14637,26 +14663,11 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
         "ignore": {
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "strip-json-comments": {
           "version": "3.1.1",
@@ -14696,6 +14707,25 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -15941,13 +15971,10 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -17304,12 +17331,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -17419,15 +17440,6 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "strip-json-comments": {
           "version": "3.1.1",
@@ -20252,13 +20264,12 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -22159,6 +22170,15 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "astral-regex": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -22310,6 +22330,16 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -22477,6 +22507,15 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "cliui": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -22617,6 +22656,16 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "levn": {
           "version": "0.3.0",
@@ -23972,7 +24021,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "sshpk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@types/debug": "4.1.7",
         "@types/jest": "26.0.24",
-        "@types/node": "^16.11.43",
+        "@types/node": "16.11.43",
         "@types/node-rsa": "1.1.1",
         "@typescript-eslint/eslint-plugin": "5.27.0",
         "@typescript-eslint/parser": "5.27.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "devDependencies": {
     "@types/debug": "4.1.7",
     "@types/jest": "26.0.24",
-    "@types/node": "^16.11.43",
+    "@types/node": "16.11.43",
     "@types/node-rsa": "1.1.1",
     "@typescript-eslint/eslint-plugin": "5.27.0",
     "@typescript-eslint/parser": "5.27.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "devDependencies": {
     "@types/debug": "4.1.7",
     "@types/jest": "26.0.24",
-    "@types/node": "16.11.43",
+    "@types/node": "^16.11.43",
     "@types/node-rsa": "1.1.1",
     "@typescript-eslint/eslint-plugin": "5.27.0",
     "@typescript-eslint/parser": "5.27.0",

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -26,7 +26,7 @@ program
     '--baseUrl <baseUrl>',
     'Change the base url for github request. For example if used on a Github Enterprise Server instance.'
   )
-  .option('-r, --repo <name>', 'Allow access to a single repository', collectRepos, [])
+  .option('-r, --repo <name>', 'Allow access to a single repository', (value: string, previous: string[]) => [...previous, value], [])
 
   .action(getTokenCommand);
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -6,10 +6,7 @@ import { getTokenCommand } from '../commands';
 
 program.name(packageJSON.name).description(packageJSON.description).version(packageJSON.version);
 
-function collectRepos(value: string, previous: string[]) {
-  return previous.concat([value]);
-}
-
+const collectRepos = (value: string, previous: string[]) => [...previous, value];
 program
   .requiredOption('--appId <appID>', 'Github App ID')
   .requiredOption(

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -6,6 +6,10 @@ import { getTokenCommand } from '../commands';
 
 program.name(packageJSON.name).description(packageJSON.description).version(packageJSON.version);
 
+function collectRepos(value: string, previous: string[]) {
+  return previous.concat([value]);
+}
+
 program
   .requiredOption('--appId <appID>', 'Github App ID')
   .requiredOption(
@@ -25,6 +29,7 @@ program
     '--baseUrl <baseUrl>',
     'Change the base url for github request. For example if used on a Github Enterprise Server instance.'
   )
+  .option('-r, --repo <name>', 'Allow access to a single repository', collectRepos, [])
 
   .action(getTokenCommand);
 

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -6,7 +6,6 @@ import { getTokenCommand } from '../commands';
 
 program.name(packageJSON.name).description(packageJSON.description).version(packageJSON.version);
 
-const collectRepos = (value: string, previous: string[]) => [...previous, value];
 program
   .requiredOption('--appId <appID>', 'Github App ID')
   .requiredOption(
@@ -26,7 +25,12 @@ program
     '--baseUrl <baseUrl>',
     'Change the base url for github request. For example if used on a Github Enterprise Server instance.'
   )
-  .option('-r, --repo <name>', 'Allow access to a single repository', (value: string, previous: string[]) => [...previous, value], [])
+  .option(
+    '-r, --repo <name>',
+    'Allow access to a single repository',
+    (value: string, previous: string[]) => [...previous, value],
+    []
+  )
 
   .action(getTokenCommand);
 

--- a/src/commands/getToken.ts
+++ b/src/commands/getToken.ts
@@ -21,6 +21,7 @@ interface GetTokenInput {
   installationId: number;
   privateKey: string;
   baseUrl?: string;
+  repositoryNames?: string[];
 }
 type RequestOptions = RequestRequestOptions & Required<{ rawResponse: true }>;
 type PlainRequest = RequestRequestOptions & { rawResponse?: false };
@@ -34,7 +35,7 @@ export async function getToken(
   requestOptions?: PlainRequest
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'>>;
 export async function getToken(
-  { appId, installationId, privateKey, baseUrl }: GetTokenInput,
+  { appId, installationId, privateKey, baseUrl, repositoryNames }: GetTokenInput,
   requestOptions?: PlainRequest | RequestOptions
 ): Promise<Pick<AppsCreateInstallationAccessTokenResponse, 'token'> | AppsCreateInstallationAccessTokenResponse> {
   const key = new NodeRSA(privateKey);
@@ -62,6 +63,7 @@ export async function getToken(
   const response = await octokit.auth({
     type: 'installation',
     installationId,
+    repositoryNames,
   });
 
   if (!isAppsCreateInstallationAccessTokenResponse(response)) {
@@ -76,6 +78,7 @@ type Input = Omit<Command & GetTokenInput, 'privateKey'> & {
   privateKeyLocation?: string;
   privateKey?: string;
   rawResponse?: boolean;
+  repo?: string[];
 };
 
 const isValidInput = (input: Input): boolean => {
@@ -90,7 +93,7 @@ export const command = async (input: Input): Promise<void> => {
   try {
     let privateKey: string;
 
-    const { privateKeyLocation, installationId, appId, rawResponse } = input;
+    const { privateKeyLocation, installationId, appId, rawResponse, baseUrl, repo } = input;
 
     if (!isValidInput(input)) {
       loader.fail('Input is not valid, either privateKey or privateKeyLocation should be provided');
@@ -103,10 +106,13 @@ export const command = async (input: Input): Promise<void> => {
       privateKey = input.privateKey as string;
     }
 
-    const response = await getToken({ privateKey, installationId, appId }, { rawResponse: true });
+    const response = await getToken(
+      { privateKey, installationId, appId, baseUrl, repositoryNames: repo },
+      { rawResponse: true }
+    );
 
     loader.stopAndPersist({
-      text: `The token is: ${response.token} and expires ${response.expiresAt}`,
+      text: `Herr token is: ${response.token} and expires ${response.expiresAt}`,
       symbol: SUCCESS_SYMBOL,
     });
 

--- a/src/commands/getToken.ts
+++ b/src/commands/getToken.ts
@@ -112,7 +112,7 @@ export const command = async (input: Input): Promise<void> => {
     );
 
     loader.stopAndPersist({
-      text: `Herr token is: ${response.token} and expires ${response.expiresAt}`,
+      text: `The token is: ${response.token} and expires ${response.expiresAt}`,
       symbol: SUCCESS_SYMBOL,
     });
 


### PR DESCRIPTION
Adds a "repo" option which can be used to restrict the token scope to only a subset of the repositories that the installed application has been granted. If the option is not given, a token with the maximum scope is returned.

```
> github-app-installation-token --appId x --installationId y --privateKeyLocation z --repo repo1 --repo repo2
```

It relates to #174 
